### PR TITLE
Add Header row to export file

### DIFF
--- a/src/UIOMaticAddons.Export/Controllers/ExportController.cs
+++ b/src/UIOMaticAddons.Export/Controllers/ExportController.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Umbraco.Core.IO;
 using Umbraco.Web.Editors;
 using System.Text;
+using UIOMatic.Models;
 
 namespace UIOMaticAddons.Export.Controllers
 {

--- a/src/UIOMaticAddons.Export/Controllers/ExportController.cs
+++ b/src/UIOMaticAddons.Export/Controllers/ExportController.cs
@@ -33,7 +33,13 @@ namespace UIOMaticAddons.Export.Controllers
 
                     //csv.WriteRecords(data);
 
-                  
+                    //Write Header Row
+					UIOMaticTypeInfo typeInfo = os.GetTypeInfo(UIOMatic.Helper.GetUIOMaticTypeByAlias(typeAlias), true);
+					foreach (var item in typeInfo.EditableProperties)
+					{
+						csv.WriteField(item.Name);
+					}
+					csv.NextRecord();
                     
 
                     foreach (var item in data)


### PR DESCRIPTION
I have used the UIOMaticField Name attribute to write out the header row.

Questions: 
1. Is this PetaPocoObjectService.GetTypeInfo() the best way to get the names of the columns?
2. Should there be an option to turn on/off the header row?